### PR TITLE
Se cambió  a request en lugar de urllib.request

### DIFF
--- a/Descarga.py
+++ b/Descarga.py
@@ -1,75 +1,57 @@
 #!/usr/local/bin/python3
 # -*- coding: utf-8 -*-
-
-import urllib.request
-from multiprocessing import Process, Manager
-
-
-class Descarga():
+import requests
+from concurrent.futures import ThreadPoolExecutor
 
 
-	def __init__(self, args = None):
-		self.url = args
+class Descarga:
+
+    def __init__(self, url):
+        self.url = url
+
+    def descarga(self, range_start, range_end):
+        headers = {'Range': 'bytes={}-{}'.format(range_start, range_end)}
+        try:
+            response = requests.get(self.url, headers=headers)
+            response.raise_for_status()
+            return response.content
+        except requests.exceptions.RequestException as e:
+            print('Error en la descarga: {}'.format(str(e)))
+            return None
+
+    def descarga_paralela(self, fragmentos, nombre):
+        try:
+            response = requests.head(self.url)
+            accept_ranges = response.headers.get('Accept-Ranges', 'none').lower()
+            if accept_ranges != 'bytes':
+                print('Descarga parcial no soportada, iniciando descarga secuencial...')
+            else:
+                print('Descarga parcial soportada')
+                size = int(response.headers.get('Content-Length', 0))
+                print("Tamaño Total: {} bytes".format(size))
+
+                tamF = size // fragmentos
+                print('Fragmentos: {}.\nTamaño aproximado por fragmento: {} bytes.'.format(fragmentos, tamF))
+
+                ranges = [(i * tamF, min((i + 1) * tamF - 1, size - 1)) for i in range(fragmentos)]
+
+                with ThreadPoolExecutor() as executor:
+                    fragmentos_descargados = list(executor.map(lambda r: self.descarga(*r), ranges))
+
+                with open(nombre, 'wb') as f:
+                    for fragmento in fragmentos_descargados:
+                        if fragmento is None:
+                            print('No se pudo descargar un fragmento. No se puede reconstruir el archivo.')
+                            break
+                        f.write(fragmento)
+                    else:
+                        print('Archivo descargado con éxito.')
+        except requests.exceptions.RequestException as e:
+            print('Error en la descarga: {}'.format(str(e)))
 
 
-	def descarga(self,orden,rango,frag):
-		"se usa try catch para menejar posibles errores"
-		try:
-			print("Obteniendo fragmeto {}. Descargando desde byte {} hasta byte {}.".format(orden,*rango))
-			"urllib.request.Requests(url) realiza la peticion a la url."
-			req = urllib.request.Request(self.url)
-			req.add_header('Range', 'bytes={}-{}'.format(*rango))
-			data = urllib.request.urlopen(req).read()
-			if data:
-				frag[orden]=data
-				print('Fragmento {} descargado correctamente. Obtenidos {} bytes.'.format(orden,len(data)))
-			else:
-				frag[orden]=None
-		except:
-			frag[orden]='#Error'
-			raise
-
-
-	def Descarga_paralela(self,fragmentos,nombre):
-		ranges=None 
-		with urllib.request.urlopen(self.url) as f:
-			'comprobamos que el servidor acepte la descarga parcial.'
-			if f.getheader("Accept-Ranges", "none").lower() != "bytes":
-				print('Descarga parcial no soportada, iniciando descarga...')
-			else:
-				print('Descarga parcial soportada')
-				'se obtiene el tamaño total del archivo.'
-				size = int(f.getheader("Content-Length", "none"))
-				print("Tamaño Total: {} bytes".format(size))
-				
-				#Dividimos ese tamaño en intervalos de acuerdo al número de procesos que lanzaremos
-				
-				tamF = size//fragmentos
-				print('Fragmentos: {}.\nTamaño aproximado por fragmento: {} bytes.'.format(fragmentos, tamF))
-				ranges = [[i, i+tamF-1] for i in range (0, size, tamF)]
-				ranges[-1][-1]=size
-				# se usa una diccionario compartido por los procesos, la clave sera el orden de cada fragmento de bytes tiene en el archivo final.
-				manager = Manager()
-				d = manager.dict()
-				# Lanza todos los procesos.
-				#target toma como parametro al metodo descarga de esta clase y args toma el
-				#orden, rango y los fragmetos en los que se desea la descarga.
-				workers = [Process(target=self.descarga, args=(i,r,d)) for i, r in enumerate(ranges)]
-				for w in workers:
-					w.start()
-				for w in workers:
-					w.join()
-				#reconstruimos el archivo usando cada fragmento en su orden correcto.
-				with open(nombre, 'wb') as f:
-					for i in range(fragmentos):
-						data = d[i]
-						if data == None or data == '#Error.':
-							print('El fragmento {} no se pude descargar. No se puede reconstruir el archivo.'.format(i))
-							break
-						else:
-							f.write(data)
-					else:
-						print('Archivo descargado con exito.')
+b = Descarga('https://upload.wikimedia.org/wikipedia/commons/thumb/5/51/Bow_Lake_beim_Icefields_Parkway.jpg/1280px-Bow_Lake_beim_Icefields_Parkway.jpg')
+b.descarga_paralela(16, 'imagen.jpg')
 
 
 


### PR DESCRIPTION
Los cambios realizados incluyen:

Uso de la biblioteca requests en lugar de urllib.request. Implementación de ThreadPoolExecutor en lugar de multiprocessing. Utilización del método get() para obtener datos descargados. Añadir manejo de errores y reintentos.
Mejora del control de errores y mensajes de salida. Estos cambios mejoran la eficiencia, la legibilidad y la capacidad de manejo de errores del código de descarga paralela.